### PR TITLE
Add Ruritania Trilogy series

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -46,6 +46,9 @@
 		<meta property="term" refines="#subject-3">sh2007101992</meta>
 		<meta property="se:subject">Adventure</meta>
 		<meta property="se:subject">Fiction</meta>
+		<meta id="collection-1" property="belongs-to-collection">Ruritania Trilogy</meta>
+		<meta property="collection-type" refines="#collection-1">series</meta>
+		<meta property="group-position" refines="#collection-1">1</meta>
 		<dc:description id="description">King Rudolph V of Ruritania is drugged and abducted on the eve of his coronation, and a gentleman on holiday who happens to look like the king has to stop the sinister plot.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;&lt;i&gt;The Prisoner of Zenda&lt;/i&gt; by &lt;a href="https://standardebooks.org/ebooks/anthony-hope"&gt;Anthony Hope&lt;/a&gt; is an adventure novel first published in 1894 that takes place in the fictional Kingdom of Ruritania.&lt;/p&gt;


### PR DESCRIPTION
[Wikipedia](https://en.wikipedia.org/wiki/Anthony_Hope#The_Ruritanian_Trilogy):

> # The Ruritanian Trilogy
> 1. [The Heart of Princess Osra](https://en.wikipedia.org/wiki/The_Heart_of_Princess_Osra), 1896.
> 2. [The Prisoner of Zenda](https://en.wikipedia.org/wiki/The_Prisoner_of_Zenda): being the history of three months in the life of an English gentleman, 1894.
> 3. [Rupert of Hentzau](https://en.wikipedia.org/wiki/Rupert_of_Hentzau): being the sequel to a story by the same writer entitled the Prisoner of Zenda, 1898.

Flipping a coin, I went with publication order instead of chronological order, and flipped another coin for “Ruritania” versus “Ruritanian.”